### PR TITLE
Skip /usr/bin symlink to fix taskswitching issue on older Pocketbooks

### DIFF
--- a/platform/pocketbook/koreader.app
+++ b/platform/pocketbook/koreader.app
@@ -15,7 +15,7 @@ export KO_PATH_OPEN_BOOK="/tmp/.koreader.open"
 INSTANCE_PID=$(cat /tmp/koreader.pid 2>/dev/null)
 if [ "${INSTANCE_PID}" != "" ] && [ -e "/proc/${INSTANCE_PID}" ]; then
     echo "$@" >"${KO_PATH_OPEN_BOOK}"
-    exec /usr/bin/iv2sh SetActiveTask "${INSTANCE_PID}" 0
+    exec /ebrmain/bin/iv2sh SetActiveTask "${INSTANCE_PID}" 0
 fi
 
 # try to bring in raw device input (on rooted devices)


### PR DESCRIPTION
I believe this fixes #11760